### PR TITLE
Make ExecError::Type take an owned String

### DIFF
--- a/isla-lib/src/error.rs
+++ b/isla-lib/src/error.rs
@@ -32,7 +32,7 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum ExecError {
-    Type(&'static str),
+    Type(String),
     Unimplemented,
     AssertionFailed(String),
     Overflow,

--- a/isla-lib/src/memory.rs
+++ b/isla-lib/src/memory.rs
@@ -371,7 +371,7 @@ impl<B: BV> Memory<B> {
 
         let data_length = crate::primop::length_bits(&data, solver)?;
         if data_length % 8 != 0 {
-            return Err(ExecError::Type("write_symbolic"));
+            return Err(ExecError::Type(format!("write_symbolic {:?}", &data_length)));
         };
         let bytes = data_length / 8;
 

--- a/isla-lib/src/primop.rs
+++ b/isla-lib/src/primop.rs
@@ -185,7 +185,7 @@ fn assume<B: BV>(x: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError>
                 Ok(Val::Unit)
             }
         }
-        _ => Err(ExecError::Type("assert")),
+        _ => Err(ExecError::Type(format!("assert {:?}", &x))),
     }
 }
 
@@ -193,7 +193,7 @@ fn assume<B: BV>(x: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError>
 fn optimistic_assert<B: BV>(x: Val<B>, message: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     let message = match message {
         Val::String(message) => message,
-        _ => return Err(ExecError::Type("optimistic_assert")),
+        _ => return Err(ExecError::Type(format!("optimistic_assert {:?}", &message))),
     };
     match x {
         Val::Symbolic(v) => {
@@ -213,7 +213,7 @@ fn optimistic_assert<B: BV>(x: Val<B>, message: Val<B>, solver: &mut Solver<B>) 
                 Err(ExecError::AssertionFailed(message))
             }
         }
-        _ => Err(ExecError::Type("optimistic_assert")),
+        _ => Err(ExecError::Type(format!("optimistic_assert {:?}", &x))),
     }
 }
 
@@ -221,7 +221,7 @@ fn optimistic_assert<B: BV>(x: Val<B>, message: Val<B>, solver: &mut Solver<B>) 
 fn pessimistic_assert<B: BV>(x: Val<B>, message: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     let message = match message {
         Val::String(message) => message,
-        _ => return Err(ExecError::Type("pessimistic_assert")),
+        _ => return Err(ExecError::Type(format!("pessimistic_assert {:?}", &message))),
     };
     match x {
         Val::Symbolic(v) => {
@@ -240,7 +240,7 @@ fn pessimistic_assert<B: BV>(x: Val<B>, message: Val<B>, solver: &mut Solver<B>)
                 Err(ExecError::AssertionFailed(message))
             }
         }
-        _ => Err(ExecError::Type("pessimistic_assert")),
+        _ => Err(ExecError::Type(format!("pessimistic_assert {:?}", &x))),
     }
 }
 
@@ -250,7 +250,7 @@ fn i64_to_i128<B: BV>(x: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecE
     match x {
         Val::I64(x) => Ok(Val::I128(i128::from(x))),
         Val::Symbolic(x) => solver.define_const(Exp::SignExtend(64, Box::new(Exp::Var(x)))).into(),
-        _ => Err(ExecError::Type("%i64->%i")),
+        _ => Err(ExecError::Type(format!("%i64->%i {:?}", &x))),
     }
 }
 
@@ -261,7 +261,7 @@ fn i128_to_i64<B: BV>(x: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecE
             Err(_) => Err(ExecError::Overflow),
         },
         Val::Symbolic(x) => solver.define_const(Exp::Extract(63, 0, Box::new(Exp::Var(x)))).into(),
-        _ => Err(ExecError::Type("%i->%i64")),
+        _ => Err(ExecError::Type(format!("%i->%i64 {:?}", &x))),
     }
 }
 
@@ -276,7 +276,7 @@ pub(crate) fn op_eq<B: BV>(x: Val<B>, y: Val<B>, solver: &mut Solver<B>) -> Resu
             } else if xs.is_empty() && ys.is_empty() {
                 Ok(Val::Bool(true))
             } else {
-                Err(ExecError::Type("op_eq"))
+                Err(ExecError::Type(format!("op_eq {:?} {:?}", &xs, &ys)))
             }
         }
         (x, y) => eq_anything(x, y, solver),
@@ -291,7 +291,7 @@ pub(crate) fn op_neq<B: BV>(x: Val<B>, y: Val<B>, solver: &mut Solver<B>) -> Res
             } else if xs.is_empty() && ys.is_empty() {
                 Ok(Val::Bool(false))
             } else {
-                Err(ExecError::Type("op_neq"))
+                Err(ExecError::Type(format!("op_neq {:?} {:?}", &xs, &ys)))
             }
         }
         (x, y) => neq_anything(x, y, solver),
@@ -302,9 +302,9 @@ pub(crate) fn op_head<B: BV>(xs: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, Ex
     match xs {
         Val::List(mut xs) => match xs.pop() {
             Some(x) => Ok(x),
-            None => Err(ExecError::Type("op_head")),
+            None => Err(ExecError::Type(format!("op_head (list empty) {:?}", &xs))),
         },
-        _ => Err(ExecError::Type("op_head")),
+        _ => Err(ExecError::Type(format!("op_head {:?}", &xs))),
     }
 }
 
@@ -314,16 +314,16 @@ pub(crate) fn op_tail<B: BV>(xs: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, Ex
             xs.pop();
             Ok(Val::List(xs))
         }
-        _ => Err(ExecError::Type("op_tail")),
+        _ => Err(ExecError::Type(format!("op_tail {:?}", &xs))),
     }
 }
 
-binary_primop!(op_lt, "op_lt", Val::I64, Val::Bool, i64::lt, Exp::Bvslt, smt_i64);
-binary_primop!(op_gt, "op_gt", Val::I64, Val::Bool, i64::gt, Exp::Bvsgt, smt_i64);
-binary_primop!(op_lteq, "op_lteq", Val::I64, Val::Bool, i64::le, Exp::Bvsle, smt_i64);
-binary_primop!(op_gteq, "op_gteq", Val::I64, Val::Bool, i64::ge, Exp::Bvsge, smt_i64);
-binary_primop_copy!(op_add, "op_add", Val::I64, Val::I64, i64::wrapping_add, Exp::Bvadd, smt_i64);
-binary_primop_copy!(op_sub, "op_sub", Val::I64, Val::I64, i64::wrapping_sub, Exp::Bvsub, smt_i64);
+binary_primop!(op_lt, "op_lt".to_string(), Val::I64, Val::Bool, i64::lt, Exp::Bvslt, smt_i64);
+binary_primop!(op_gt, "op_gt".to_string(), Val::I64, Val::Bool, i64::gt, Exp::Bvsgt, smt_i64);
+binary_primop!(op_lteq, "op_lteq".to_string(), Val::I64, Val::Bool, i64::le, Exp::Bvsle, smt_i64);
+binary_primop!(op_gteq, "op_gteq".to_string(), Val::I64, Val::Bool, i64::ge, Exp::Bvsge, smt_i64);
+binary_primop_copy!(op_add, "op_add".to_string(), Val::I64, Val::I64, i64::wrapping_add, Exp::Bvadd, smt_i64);
+binary_primop_copy!(op_sub, "op_sub".to_string(), Val::I64, Val::I64, i64::wrapping_sub, Exp::Bvsub, smt_i64);
 
 pub(crate) fn bit_to_bool<B: BV>(bit: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match bit {
@@ -331,7 +331,7 @@ pub(crate) fn bit_to_bool<B: BV>(bit: Val<B>, solver: &mut Solver<B>) -> Result<
         Val::Symbolic(bit) => {
             solver.define_const(Exp::Eq(Box::new(Exp::Bits([true].to_vec())), Box::new(Exp::Var(bit)))).into()
         }
-        _ => Err(ExecError::Type("bit_to_bool")),
+        _ => Err(ExecError::Type(format!("bit_to_bool {:?}", &bit))),
     }
 }
 
@@ -340,9 +340,9 @@ pub(crate) fn op_unsigned<B: BV>(bits: Val<B>, solver: &mut Solver<B>) -> Result
         Val::Bits(bits) => Ok(Val::I64(bits.unsigned() as i64)),
         Val::Symbolic(bits) => match solver.length(bits) {
             Some(length) => solver.define_const(Exp::ZeroExtend(64 - length, Box::new(Exp::Var(bits)))).into(),
-            None => Err(ExecError::Type("op_unsigned")),
+            None => Err(ExecError::Type(format!("op_unsigned {:?}", &bits))),
         },
-        _ => Err(ExecError::Type("op_unsigned")),
+        _ => Err(ExecError::Type(format!("op_unsigned {:?}", &bits))),
     }
 }
 
@@ -351,23 +351,23 @@ pub(crate) fn op_signed<B: BV>(bits: Val<B>, solver: &mut Solver<B>) -> Result<V
         Val::Bits(bits) => Ok(Val::I64(bits.signed() as i64)),
         Val::Symbolic(bits) => match solver.length(bits) {
             Some(length) => solver.define_const(Exp::SignExtend(64 - length, Box::new(Exp::Var(bits)))).into(),
-            None => Err(ExecError::Type("op_unsigned")),
+            None => Err(ExecError::Type(format!("op_unsigned (solver cannot determine length) {:?}", &bits))),
         },
-        _ => Err(ExecError::Type("op_unsigned")),
+        _ => Err(ExecError::Type(format!("op_unsigned {:?}", &bits))),
     }
 }
 
 // Basic comparisons
 
-unary_primop_copy!(not_bool, "not", Val::Bool, Val::Bool, bool::not, Exp::Not);
-binary_primop_copy!(and_bool, "and_bool", Val::Bool, Val::Bool, bool::bitand, Exp::And, Exp::Bool);
-binary_primop_copy!(or_bool, "or_bool", Val::Bool, Val::Bool, bool::bitor, Exp::Or, Exp::Bool);
-binary_primop!(eq_int, "eq_int", Val::I128, Val::Bool, i128::eq, Exp::Eq, smt_i128);
-binary_primop!(eq_bool, "eq_bool", Val::Bool, Val::Bool, bool::eq, Exp::Eq, Exp::Bool);
-binary_primop!(lteq_int, "lteq", Val::I128, Val::Bool, i128::le, Exp::Bvsle, smt_i128);
-binary_primop!(gteq_int, "gteq", Val::I128, Val::Bool, i128::ge, Exp::Bvsge, smt_i128);
-binary_primop!(lt_int, "lt", Val::I128, Val::Bool, i128::lt, Exp::Bvslt, smt_i128);
-binary_primop!(gt_int, "gt", Val::I128, Val::Bool, i128::gt, Exp::Bvsgt, smt_i128);
+unary_primop_copy!(not_bool, "not".to_string(), Val::Bool, Val::Bool, bool::not, Exp::Not);
+binary_primop_copy!(and_bool, "and_bool".to_string(), Val::Bool, Val::Bool, bool::bitand, Exp::And, Exp::Bool);
+binary_primop_copy!(or_bool, "or_bool".to_string(), Val::Bool, Val::Bool, bool::bitor, Exp::Or, Exp::Bool);
+binary_primop!(eq_int, "eq_int".to_string(), Val::I128, Val::Bool, i128::eq, Exp::Eq, smt_i128);
+binary_primop!(eq_bool, "eq_bool".to_string(), Val::Bool, Val::Bool, bool::eq, Exp::Eq, Exp::Bool);
+binary_primop!(lteq_int, "lteq".to_string(), Val::I128, Val::Bool, i128::le, Exp::Bvsle, smt_i128);
+binary_primop!(gteq_int, "gteq".to_string(), Val::I128, Val::Bool, i128::ge, Exp::Bvsge, smt_i128);
+binary_primop!(lt_int, "lt".to_string(), Val::I128, Val::Bool, i128::lt, Exp::Bvslt, smt_i128);
+binary_primop!(gt_int, "gt".to_string(), Val::I128, Val::Bool, i128::gt, Exp::Bvsgt, smt_i128);
 
 fn abs_int<B: BV>(x: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match x {
@@ -384,22 +384,22 @@ fn abs_int<B: BV>(x: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError
             ));
             Ok(Val::Symbolic(y))
         }
-        _ => Err(ExecError::Type("abs_int")),
+        _ => Err(ExecError::Type(format!("abs_int {:?}", &x))),
     }
 }
 
 // Arithmetic operations
 
-binary_primop_copy!(sub_int, "sub_int", Val::I128, Val::I128, i128::wrapping_sub, Exp::Bvsub, smt_i128);
-binary_primop_copy!(mult_int, "mult_int", Val::I128, Val::I128, i128::wrapping_mul, Exp::Bvmul, smt_i128);
-unary_primop_copy!(neg_int, "neg_int", Val::I128, Val::I128, i128::wrapping_neg, Exp::Bvneg);
-binary_primop_copy!(tdiv_int, "tdiv_int", Val::I128, Val::I128, i128::wrapping_div, Exp::Bvsdiv, smt_i128);
-binary_primop_copy!(tmod_int, "tmod_int", Val::I128, Val::I128, i128::wrapping_rem, Exp::Bvsmod, smt_i128);
-binary_primop_copy!(shl_int, "shl_int", Val::I128, Val::I128, i128::shl, Exp::Bvshl, smt_i128);
-binary_primop_copy!(shr_int, "shr_int", Val::I128, Val::I128, i128::shr, Exp::Bvashr, smt_i128);
-binary_primop_copy!(shl_mach_int, "shl_mach_int", Val::I64, Val::I64, i64::shl, Exp::Bvshl, smt_i64);
-binary_primop_copy!(shr_mach_int, "shr_mach_int", Val::I64, Val::I64, i64::shr, Exp::Bvashr, smt_i64);
-binary_primop_copy!(udiv_int, "udiv_int", Val::I128, Val::I128, i128::wrapping_div, Exp::Bvudiv, smt_i128);
+binary_primop_copy!(sub_int, "sub_int".to_string(), Val::I128, Val::I128, i128::wrapping_sub, Exp::Bvsub, smt_i128);
+binary_primop_copy!(mult_int, "mult_int".to_string(), Val::I128, Val::I128, i128::wrapping_mul, Exp::Bvmul, smt_i128);
+unary_primop_copy!(neg_int, "neg_int".to_string(), Val::I128, Val::I128, i128::wrapping_neg, Exp::Bvneg);
+binary_primop_copy!(tdiv_int, "tdiv_int".to_string(), Val::I128, Val::I128, i128::wrapping_div, Exp::Bvsdiv, smt_i128);
+binary_primop_copy!(tmod_int, "tmod_int".to_string(), Val::I128, Val::I128, i128::wrapping_rem, Exp::Bvsmod, smt_i128);
+binary_primop_copy!(shl_int, "shl_int".to_string(), Val::I128, Val::I128, i128::shl, Exp::Bvshl, smt_i128);
+binary_primop_copy!(shr_int, "shr_int".to_string(), Val::I128, Val::I128, i128::shr, Exp::Bvashr, smt_i128);
+binary_primop_copy!(shl_mach_int, "shl_mach_int".to_string(), Val::I64, Val::I64, i64::shl, Exp::Bvshl, smt_i64);
+binary_primop_copy!(shr_mach_int, "shr_mach_int".to_string(), Val::I64, Val::I64, i64::shr, Exp::Bvashr, smt_i64);
+binary_primop_copy!(udiv_int, "udiv_int".to_string(), Val::I128, Val::I128, i128::wrapping_div, Exp::Bvudiv, smt_i128);
 
 pub(crate) fn add_int<B: BV>(x: Val<B>, y: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match (x, y) {
@@ -421,7 +421,7 @@ pub(crate) fn add_int<B: BV>(x: Val<B>, y: Val<B>, solver: &mut Solver<B>) -> Re
             }
         }
         (Val::I128(x), Val::I128(y)) => Ok(Val::I128(i128::wrapping_add(x, y))),
-        (_, _) => Err(ExecError::Type("add_int")),
+        (x, y) => Err(ExecError::Type(format!("add_int {:?} {:?}", &x, &y))),
     }
 }
 
@@ -440,7 +440,7 @@ fn max_int<B: BV>(x: Val<B>, y: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>
         (Val::I128(x), Val::Symbolic(y)) => symbolic_compare!(Exp::Bvsgt, smt_i128(x), Exp::Var(y), solver),
         (Val::Symbolic(x), Val::I128(y)) => symbolic_compare!(Exp::Bvsgt, Exp::Var(x), smt_i128(y), solver),
         (Val::Symbolic(x), Val::Symbolic(y)) => symbolic_compare!(Exp::Bvsgt, Exp::Var(x), Exp::Var(y), solver),
-        (_, _) => Err(ExecError::Type("max_int")),
+        (x, y) => Err(ExecError::Type(format!("max_int {:?} {:?}", &x, &y))),
     }
 }
 
@@ -450,7 +450,7 @@ fn min_int<B: BV>(x: Val<B>, y: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>
         (Val::I128(x), Val::Symbolic(y)) => symbolic_compare!(Exp::Bvslt, smt_i128(x), Exp::Var(y), solver),
         (Val::Symbolic(x), Val::I128(y)) => symbolic_compare!(Exp::Bvslt, Exp::Var(x), smt_i128(y), solver),
         (Val::Symbolic(x), Val::Symbolic(y)) => symbolic_compare!(Exp::Bvslt, Exp::Var(x), Exp::Var(y), solver),
-        (_, _) => Err(ExecError::Type("max_int")),
+        (x, y) => Err(ExecError::Type(format!("max_int {:?} {:?}", &x, &y))),
     }
 }
 
@@ -458,14 +458,14 @@ fn pow2<B: BV>(x: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match x {
         Val::I128(x) => Ok(Val::I128(1 << x)),
         Val::Symbolic(x) => solver.define_const(Exp::Bvshl(Box::new(smt_i128(1)), Box::new(Exp::Var(x)))).into(),
-        _ => Err(ExecError::Type("pow2")),
+        _ => Err(ExecError::Type(format!("pow2 {:?}", &x))),
     }
 }
 
 fn pow_int<B: BV>(x: Val<B>, y: Val<B>, _solver: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match (x, y) {
         (Val::I128(x), Val::I128(y)) => Ok(Val::I128(x.pow(y.try_into().map_err(|_| ExecError::Overflow)?))),
-        (_, _) => Err(ExecError::Type("pow_int")),
+        (x, y) => Err(ExecError::Type(format!("pow_int {:?} {:?}", &x, &y))),
     }
 }
 
@@ -481,7 +481,7 @@ fn sub_nat<B: BV>(x: Val<B>, y: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>
         (Val::Symbolic(x), Val::Symbolic(y)) => {
             symbolic_compare!(Exp::Bvsgt, Exp::Bvsub(Box::new(Exp::Var(x)), Box::new(Exp::Var(y))), smt_i128(0), solver)
         }
-        (_, _) => Err(ExecError::Type("sub_nat")),
+        (x, y) => Err(ExecError::Type(format!("sub_nat {:?} {:?}", &x, &y))),
     }
 }
 
@@ -491,21 +491,21 @@ fn length<B: BV>(x: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError>
     match x {
         Val::Symbolic(v) => match solver.length(v) {
             Some(len) => Ok(Val::I128(i128::from(len))),
-            None => Err(ExecError::Type("length")),
+            None => Err(ExecError::Type(format!("length (solver cannot determine length) {:?}", &v))),
         },
         Val::Bits(bv) => Ok(Val::I128(bv.len_i128())),
-        _ => Err(ExecError::Type("length")),
+        _ => Err(ExecError::Type(format!("length {:?}", &x))),
     }
 }
 
-binary_primop!(eq_bits, "eq_bits", Val::Bits, Val::Bool, B::eq, Exp::Eq, smt_sbits);
-binary_primop!(neq_bits, "neq_bits", Val::Bits, Val::Bool, B::ne, Exp::Neq, smt_sbits);
-unary_primop_copy!(not_bits, "not_bits", Val::Bits, Val::Bits, B::not, Exp::Bvnot);
-binary_primop_copy!(xor_bits, "xor_bits", Val::Bits, Val::Bits, B::bitxor, Exp::Bvxor, smt_sbits);
-binary_primop_copy!(or_bits, "or_bits", Val::Bits, Val::Bits, B::bitor, Exp::Bvor, smt_sbits);
-binary_primop_copy!(and_bits, "and_bits", Val::Bits, Val::Bits, B::bitand, Exp::Bvand, smt_sbits);
-binary_primop_copy!(add_bits, "add_bits", Val::Bits, Val::Bits, B::add, Exp::Bvadd, smt_sbits);
-binary_primop_copy!(sub_bits, "sub_bits", Val::Bits, Val::Bits, B::sub, Exp::Bvsub, smt_sbits);
+binary_primop!(eq_bits, "eq_bits".to_string(), Val::Bits, Val::Bool, B::eq, Exp::Eq, smt_sbits);
+binary_primop!(neq_bits, "neq_bits".to_string(), Val::Bits, Val::Bool, B::ne, Exp::Neq, smt_sbits);
+unary_primop_copy!(not_bits, "not_bits".to_string(), Val::Bits, Val::Bits, B::not, Exp::Bvnot);
+binary_primop_copy!(xor_bits, "xor_bits".to_string(), Val::Bits, Val::Bits, B::bitxor, Exp::Bvxor, smt_sbits);
+binary_primop_copy!(or_bits, "or_bits".to_string(), Val::Bits, Val::Bits, B::bitor, Exp::Bvor, smt_sbits);
+binary_primop_copy!(and_bits, "and_bits".to_string(), Val::Bits, Val::Bits, B::bitand, Exp::Bvand, smt_sbits);
+binary_primop_copy!(add_bits, "add_bits".to_string(), Val::Bits, Val::Bits, B::add, Exp::Bvadd, smt_sbits);
+binary_primop_copy!(sub_bits, "sub_bits".to_string(), Val::Bits, Val::Bits, B::sub, Exp::Bvsub, smt_sbits);
 
 fn add_bits_int<B: BV>(bits: Val<B>, n: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match (bits, n) {
@@ -514,7 +514,7 @@ fn add_bits_int<B: BV>(bits: Val<B>, n: Val<B>, solver: &mut Solver<B>) -> Resul
             let result = solver.fresh();
             let len = match solver.length(bits) {
                 Some(len) => len,
-                None => return Err(ExecError::Type("add_bits_int")),
+                None => return Err(ExecError::Type(format!("add_bits_int (solver cannot determine length) {:?} {:?}", &bits, &n))),
             };
             assert!(len <= 128);
             solver.add(Def::DefineConst(
@@ -527,7 +527,7 @@ fn add_bits_int<B: BV>(bits: Val<B>, n: Val<B>, solver: &mut Solver<B>) -> Resul
             let result = solver.fresh();
             let len = match solver.length(bits) {
                 Some(len) => len,
-                None => return Err(ExecError::Type("add_bits_int")),
+                None => return Err(ExecError::Type(format!("add_bits_int (solver cannot determine length) {:?} {:?}", &bits, &n))),
             };
             assert!(len <= 128);
             solver.add(Def::DefineConst(
@@ -536,7 +536,7 @@ fn add_bits_int<B: BV>(bits: Val<B>, n: Val<B>, solver: &mut Solver<B>) -> Resul
             ));
             Ok(Val::Symbolic(result))
         }
-        (_, _) => Err(ExecError::Type("add_bits_int")),
+        (bits, n) => Err(ExecError::Type(format!("add_bits_int {:?} {:?}", &bits, &n))),
     }
 }
 
@@ -547,7 +547,7 @@ fn sub_bits_int<B: BV>(bits: Val<B>, n: Val<B>, solver: &mut Solver<B>) -> Resul
             let result = solver.fresh();
             let len = match solver.length(bits) {
                 Some(len) => len,
-                None => return Err(ExecError::Type("sub_bits_int")),
+                None => return Err(ExecError::Type(format!("sub_bits_int (solver cannot determine length) {:?} {:?}", &bits, &n))),
             };
             assert!(len <= 128);
             solver.add(Def::DefineConst(
@@ -560,7 +560,7 @@ fn sub_bits_int<B: BV>(bits: Val<B>, n: Val<B>, solver: &mut Solver<B>) -> Resul
             let result = solver.fresh();
             let len = match solver.length(bits) {
                 Some(len) => len,
-                None => return Err(ExecError::Type("sub_bits_int")),
+                None => return Err(ExecError::Type(format!("sub_bits_int (solver cannot determine length) {:?} {:?}", &bits, &n))),
             };
             assert!(len <= 128);
             solver.add(Def::DefineConst(
@@ -569,7 +569,7 @@ fn sub_bits_int<B: BV>(bits: Val<B>, n: Val<B>, solver: &mut Solver<B>) -> Resul
             ));
             Ok(Val::Symbolic(result))
         }
-        (_, _) => Err(ExecError::Type("sub_bits_int")),
+        (bits, n) => Err(ExecError::Type(format!("sub_bits_int {:?} {:?}", &bits, &n))),
     }
 }
 
@@ -583,7 +583,7 @@ fn zeros<B: BV>(len: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError
             }
         }
         Val::Symbolic(_) => Err(ExecError::SymbolicLength("zeros")),
-        _ => Err(ExecError::Type("zeros")),
+        _ => Err(ExecError::Type(format!("zeros {:?}", &len))),
     }
 }
 
@@ -597,7 +597,7 @@ fn ones<B: BV>(len: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError>
             }
         }
         Val::Symbolic(_) => Err(ExecError::SymbolicLength("ones")),
-        _ => Err(ExecError::Type("ones")),
+        _ => Err(ExecError::Type(format!("ones {:?}", &len))),
     }
 }
 
@@ -630,8 +630,8 @@ macro_rules! extension {
     };
 }
 
-extension!(zero_extend, "zero_extend", Exp::ZeroExtend, B::zero_extend);
-extension!(sign_extend, "sign_extend", Exp::SignExtend, B::sign_extend);
+extension!(zero_extend, "zero_extend".to_string(), Exp::ZeroExtend, B::zero_extend);
+extension!(sign_extend, "sign_extend".to_string(), Exp::SignExtend, B::sign_extend);
 
 pub(crate) fn op_zero_extend<B: BV>(bits: Val<B>, len: u32, solver: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match bits {
@@ -646,11 +646,11 @@ pub(crate) fn op_zero_extend<B: BV>(bits: Val<B>, len: u32, solver: &mut Solver<
         Val::Symbolic(bits) => {
             let ext = match solver.length(bits) {
                 Some(orig_len) => len - orig_len,
-                None => return Err(ExecError::Type("op_zero_extend")),
+                None => return Err(ExecError::Type(format!("op_zero_extend (solver cannot determine length) {:?}", &bits))),
             };
             solver.define_const(Exp::ZeroExtend(ext, Box::new(Exp::Var(bits)))).into()
         }
-        _ => Err(ExecError::Type("op_zero_extend")),
+        _ => Err(ExecError::Type(format!("op_zero_extend {:?}", &bits))),
     }
 }
 
@@ -677,7 +677,7 @@ fn replicate_bits<B: BV>(bits: Val<B>, times: Val<B>, solver: &mut Solver<B>) ->
                 solver.define_const(replicate_exp(Exp::Var(bits), times)).into()
             }
         }
-        (_, _) => Err(ExecError::Type("replicate_bits")),
+        (bits, times) => Err(ExecError::Type(format!("replicate_bits {:?} {:?}", &bits, &times))),
     }
 }
 
@@ -689,9 +689,9 @@ pub fn length_bits<B: BV>(bits: &Val<B>, solver: &mut Solver<B>) -> Result<u32, 
         Val::Bits(bits) => Ok(bits.len()),
         Val::Symbolic(bits) => match solver.length(*bits) {
             Some(len) => Ok(len),
-            None => Err(ExecError::Type("length_bits")),
+            None => Err(ExecError::Type(format!("length_bits (solver cannot determine length) {:?}", &bits))),
         },
-        _ => Err(ExecError::Type("length_bits")),
+        _ => Err(ExecError::Type(format!("length_bits {:?}", &bits))),
     }
 }
 
@@ -750,7 +750,7 @@ macro_rules! slice {
                 Ok(Val::Symbolic(sliced))
             }
 
-            _ => Err(ExecError::Type("slice!")),
+            _ => Err(ExecError::Type(format!("slice! {:?}", &$from))),
         }
     }};
 }
@@ -767,12 +767,12 @@ pub(crate) fn op_slice<B: BV>(
         Val::Bits(bits) => match from {
             Val::I64(from) => match bits.slice(from as u32, length) {
                 Some(bits) => Ok(Val::Bits(bits)),
-                None => Err(ExecError::Type("op_slice")),
+                None => Err(ExecError::Type("op_slice (can't slice)".to_string())),
             },
             _ if bits.is_zero() => Ok(Val::Bits(B::zeros(bits_length))),
             _ => slice!(bits_length, smt_sbits(bits), from, length as i128, solver),
         },
-        _ => Err(ExecError::Type("op_slice")),
+        _ => Err(ExecError::Type(format!("op_slice {:?}", &bits))),
     }
 }
 
@@ -795,17 +795,17 @@ fn slice_internal<B: BV>(
                         // of the symbolic case but isn't tested because the results aren't used.
                         match bits.shiftr(from).slice(0, length as u32) {
                             Some(bits) => Ok(Val::Bits(bits)),
-                            None => Err(ExecError::Type("slice_internal")),
+                            None => Err(ExecError::Type(format!("slice_internal (cannot slice) {:?} {:?}", &from, &length))),
                         }
                     }
                 },
                 _ if bits.is_zero() => Ok(Val::Bits(B::zeros(bits_length))),
                 _ => slice!(bits_length, smt_sbits(bits), from, length, solver),
             },
-            _ => Err(ExecError::Type("slice_internal")),
+            _ => Err(ExecError::Type(format!("slice_internal {:?}", &bits))),
         },
         Val::Symbolic(_) => Err(ExecError::SymbolicLength("slice_internal")),
-        _ => Err(ExecError::Type("slice_internal")),
+        _ => Err(ExecError::Type(format!("slice_internal {:?}", &length))),
     }
 }
 
@@ -825,11 +825,11 @@ fn subrange_internal<B: BV>(
         }
         (Val::Bits(bits), Val::I128(high), Val::I128(low)) => match bits.extract(high as u32, low as u32) {
             Some(bits) => Ok(Val::Bits(bits)),
-            None => Err(ExecError::Type("subrange_internal")),
+            None => Err(ExecError::Type(format!("subrange_internal (cannot extract) {:?} {:?} {:?}", &bits, &high, &low))),
         },
         (_, _, Val::Symbolic(_)) => Err(ExecError::SymbolicLength("subrange_internal")),
         (_, Val::Symbolic(_), _) => Err(ExecError::SymbolicLength("subrange_internal")),
-        (_, _, _) => Err(ExecError::Type("subrange_internal")),
+        (bits, high, low) => Err(ExecError::Type(format!("subrange_internal {:?} {:?} {:?}", &bits, &high, &low))),
     }
 }
 
@@ -845,7 +845,7 @@ fn sail_truncate_lsb<B: BV>(bits: Val<B>, len: Val<B>, solver: &mut Solver<B>) -
     match (bits, len) {
         (Val::Bits(bits), Val::I128(len)) => match bits.truncate_lsb(len) {
             Some(truncated) => Ok(Val::Bits(truncated)),
-            None => Err(ExecError::Type("sail_truncateLSB")),
+            None => Err(ExecError::Type(format!("sail_truncateLSB (cannot truncate) {:?} {:?}", &bits, &len))),
         },
         (Val::Symbolic(bits), Val::I128(len)) => {
             if len == 0 {
@@ -854,11 +854,11 @@ fn sail_truncate_lsb<B: BV>(bits: Val<B>, len: Val<B>, solver: &mut Solver<B>) -
                 let low = orig_len - (len as u32);
                 solver.define_const(Exp::Extract(orig_len - 1, low, Box::new(Exp::Var(bits)))).into()
             } else {
-                Err(ExecError::Type("sail_truncateLSB"))
+                Err(ExecError::Type(format!("sail_truncateLSB (invalid length) {:?} {:?}", &bits, &len)))
             }
         }
         (_, Val::Symbolic(_)) => Err(ExecError::SymbolicLength("sail_truncateLSB")),
-        (_, _) => Err(ExecError::Type("sail_truncateLSB")),
+        (bits, len) => Err(ExecError::Type(format!("sail_truncateLSB {:?} {:?}", &bits, &len))),
     }
 }
 
@@ -870,9 +870,9 @@ fn sail_unsigned<B: BV>(bits: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, 
                 assert!(length < 128);
                 solver.define_const(Exp::ZeroExtend(128 - length, Box::new(Exp::Var(bits)))).into()
             }
-            None => Err(ExecError::Type("sail_unsigned")),
+            None => Err(ExecError::Type(format!("sail_unsigned (solver cannot determine length) {:?}", &bits))),
         },
-        _ => Err(ExecError::Type("sail_unsigned")),
+        _ => Err(ExecError::Type(format!("sail_unsigned {:?}", &bits))),
     }
 }
 
@@ -884,9 +884,9 @@ fn sail_signed<B: BV>(bits: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, Ex
                 assert!(length < 128);
                 solver.define_const(Exp::SignExtend(128 - length, Box::new(Exp::Var(bits)))).into()
             }
-            None => Err(ExecError::Type("sail_signed")),
+            None => Err(ExecError::Type(format!("sail_signed (solver cannot determine length) {:?}", &bits))),
         },
-        _ => Err(ExecError::Type("sail_signed")),
+        _ => Err(ExecError::Type(format!("sail_signed {:?}", &bits))),
     }
 }
 
@@ -903,7 +903,7 @@ fn shiftr<B: BV>(bits: Val<B>, shift: Val<B>, solver: &mut Solver<B>) -> Result<
                 };
                 solver.define_const(Exp::Bvlshr(Box::new(Exp::Var(x)), Box::new(shift))).into()
             }
-            None => Err(ExecError::Type("shiftr")),
+            None => Err(ExecError::Type(format!("shiftr {:?} {:?}", &x, &y))),
         },
         (Val::Symbolic(x), Val::I128(0)) => Ok(Val::Symbolic(x)),
         (Val::Symbolic(x), Val::I128(y)) => match solver.length(x) {
@@ -917,7 +917,7 @@ fn shiftr<B: BV>(bits: Val<B>, shift: Val<B>, solver: &mut Solver<B>) -> Result<
                 };
                 solver.define_const(Exp::Bvlshr(Box::new(Exp::Var(x)), Box::new(shift))).into()
             }
-            None => Err(ExecError::Type("shiftr")),
+            None => Err(ExecError::Type(format!("shiftr {:?} {:?}", &x, &y))),
         },
         (Val::Bits(x), Val::Symbolic(y)) => solver
             .define_const(Exp::Bvlshr(
@@ -926,7 +926,7 @@ fn shiftr<B: BV>(bits: Val<B>, shift: Val<B>, solver: &mut Solver<B>) -> Result<
             ))
             .into(),
         (Val::Bits(x), Val::I128(y)) => Ok(Val::Bits(x.shiftr(y))),
-        (_, _) => Err(ExecError::Type("shiftr")),
+        (bits, shift) => Err(ExecError::Type(format!("shiftr {:?} {:?}", &bits, &shift))),
     }
 }
 
@@ -943,7 +943,7 @@ fn arith_shiftr<B: BV>(bits: Val<B>, shift: Val<B>, solver: &mut Solver<B>) -> R
                 };
                 solver.define_const(Exp::Bvashr(Box::new(Exp::Var(x)), Box::new(shift))).into()
             }
-            None => Err(ExecError::Type("arith_shiftr")),
+            None => Err(ExecError::Type(format!("arith_shiftr {:?} {:?}", &x, &y))),
         },
         (Val::Symbolic(x), Val::I128(0)) => Ok(Val::Symbolic(x)),
         (Val::Symbolic(x), Val::I128(y)) => match solver.length(x) {
@@ -957,7 +957,7 @@ fn arith_shiftr<B: BV>(bits: Val<B>, shift: Val<B>, solver: &mut Solver<B>) -> R
                 };
                 solver.define_const(Exp::Bvashr(Box::new(Exp::Var(x)), Box::new(shift))).into()
             }
-            None => Err(ExecError::Type("arith_shiftr")),
+            None => Err(ExecError::Type(format!("arith_shiftr {:?} {:?}", &x, &y))),
         },
         (Val::Bits(x), Val::Symbolic(y)) => solver
             .define_const(Exp::Bvashr(
@@ -966,7 +966,7 @@ fn arith_shiftr<B: BV>(bits: Val<B>, shift: Val<B>, solver: &mut Solver<B>) -> R
             ))
             .into(),
         (Val::Bits(x), Val::I128(y)) => Ok(Val::Bits(x.arith_shiftr(y))),
-        (_, _) => Err(ExecError::Type("arith_shiftr")),
+        (bits, shift) => Err(ExecError::Type(format!("arith_shiftr {:?} {:?}", &bits, &shift))),
     }
 }
 
@@ -983,7 +983,7 @@ fn shiftl<B: BV>(bits: Val<B>, len: Val<B>, solver: &mut Solver<B>) -> Result<Va
                 };
                 solver.define_const(Exp::Bvshl(Box::new(Exp::Var(x)), Box::new(shift))).into()
             }
-            None => Err(ExecError::Type("shiftl")),
+            None => Err(ExecError::Type(format!("shiftl {:?} {:?}", &x, &y))),
         },
         (Val::Symbolic(x), Val::I128(0)) => Ok(Val::Symbolic(x)),
         (Val::Symbolic(x), Val::I128(y)) => match solver.length(x) {
@@ -997,7 +997,7 @@ fn shiftl<B: BV>(bits: Val<B>, len: Val<B>, solver: &mut Solver<B>) -> Result<Va
                 };
                 solver.define_const(Exp::Bvshl(Box::new(Exp::Var(x)), Box::new(shift))).into()
             }
-            None => Err(ExecError::Type("shiftl")),
+            None => Err(ExecError::Type(format!("shiftl {:?} {:?}", &x, &y))),
         },
         (Val::Bits(x), Val::Symbolic(y)) => solver
             .define_const(Exp::Bvshl(
@@ -1006,7 +1006,7 @@ fn shiftl<B: BV>(bits: Val<B>, len: Val<B>, solver: &mut Solver<B>) -> Result<Va
             ))
             .into(),
         (Val::Bits(x), Val::I128(y)) => Ok(Val::Bits(x.shiftl(y))),
-        (_, _) => Err(ExecError::Type("shiftl")),
+        (bits, len) => Err(ExecError::Type(format!("shiftl {:?} {:?}", &bits, &len))),
     }
 }
 
@@ -1028,7 +1028,7 @@ fn shift_bits_right<B: BV>(bits: Val<B>, shift: Val<B>, solver: &mut Solver<B>) 
             let shift: u64 = (*y).try_into()?;
             Ok(Val::Bits(x.shiftr(shift as i128)))
         }
-        (_, _) => Err(ExecError::Type("shift_bits_right")),
+        (_, _) => Err(ExecError::Type(format!("shift_bits_right {:?} {:?}", &bits, &shift))),
     }
 }
 
@@ -1050,7 +1050,7 @@ fn shift_bits_left<B: BV>(bits: Val<B>, shift: Val<B>, solver: &mut Solver<B>) -
             let shift: u64 = (*y).try_into()?;
             Ok(Val::Bits(x.shiftl(shift as i128)))
         }
-        (_, _) => Err(ExecError::Type("shift_bits_left")),
+        (_, _) => Err(ExecError::Type(format!("shift_bits_left {:?} {:?}", &bits, &shift))),
     }
 }
 
@@ -1077,7 +1077,7 @@ pub(crate) fn append<B: BV>(lhs: Val<B>, rhs: Val<B>, solver: &mut Solver<B>) ->
             Some(z) => Ok(Val::Bits(z)),
             None => solver.define_const(Exp::Concat(Box::new(smt_sbits(x)), Box::new(smt_sbits(y)))).into(),
         },
-        (_, _) => Err(ExecError::Type("append")),
+        (lhs, rhs) => Err(ExecError::Type(format!("append {:?} {:?}", &lhs, &rhs))),
     }
 }
 
@@ -1096,7 +1096,7 @@ pub(crate) fn vector_access<B: BV>(vec: Val<B>, n: Val<B>, solver: &mut Solver<B
                     .define_const(Exp::Extract(0, 0, Box::new(Exp::Bvlshr(Box::new(Exp::Var(bits)), Box::new(shift)))))
                     .into()
             }
-            None => Err(ExecError::Type("vector_access")),
+            None => Err(ExecError::Type(format!("vector_access {:?} {:?}", &bits, &n))),
         },
         (Val::Symbolic(bits), Val::I128(n)) => match solver.length(bits) {
             Some(length) => {
@@ -1111,7 +1111,7 @@ pub(crate) fn vector_access<B: BV>(vec: Val<B>, n: Val<B>, solver: &mut Solver<B
                     .define_const(Exp::Extract(0, 0, Box::new(Exp::Bvlshr(Box::new(Exp::Var(bits)), Box::new(shift)))))
                     .into()
             }
-            None => Err(ExecError::Type("vector_access")),
+            None => Err(ExecError::Type(format!("vector_access {:?} {:?}", &bits, &n))),
         },
         (Val::Bits(bits), Val::Symbolic(n)) => {
             let shift = Exp::Extract(bits.len() - 1, 0, Box::new(Exp::Var(n)));
@@ -1121,13 +1121,13 @@ pub(crate) fn vector_access<B: BV>(vec: Val<B>, n: Val<B>, solver: &mut Solver<B
         }
         (Val::Bits(bits), Val::I128(n)) => match bits.slice(n as u32, 1) {
             Some(bit) => Ok(Val::Bits(bit)),
-            None => Err(ExecError::Type("vector_access")),
+            None => Err(ExecError::Type(format!("vector_access {:?} {:?}", &bits, &n))),
         },
         (Val::Vector(vec), Val::I128(n)) => match vec.get(n as usize) {
             Some(elem) => Ok(elem.clone()),
             None => Err(ExecError::OutOfBounds("vector_access")),
         },
-        (_, _) => Err(ExecError::Type("vector_access")),
+        (vec, n) => Err(ExecError::Type(format!("vector_access {:?} {:?}", &vec, &n))),
     }
 }
 
@@ -1245,7 +1245,7 @@ fn set_slice_internal<B: BV>(
             }
         }
         (Val::Bits(bits), Val::I128(n), Val::Bits(update)) => Ok(Val::Bits(bits.set_slice(n as u32, update))),
-        (_, _, _) => Err(ExecError::Type("set_slice")),
+        (bits, n, update) => Err(ExecError::Type(format!("set_slice {:?} {:?} {:?}", &bits, &n, &update))),
     }
 }
 
@@ -1297,7 +1297,7 @@ fn set_slice_int_internal<B: BV>(
             }
         }
         (Val::I128(int), Val::I128(n), Val::Bits(update)) => Ok(Val::I128(B::set_slice_int(int, n as u32, update))),
-        (_, _, _) => Err(ExecError::Type("set_slice_int")),
+        (int, n, update) => Err(ExecError::Type(format!("set_slice_int {:?} {:?} {:?}", &int, &n, &update))),
     }
 }
 
@@ -1351,7 +1351,7 @@ pub(crate) fn op_set_slice<B: BV>(
             }
         }
         (Val::Bits(bits), Val::I64(n), Val::Bits(update)) => Ok(Val::Bits(bits.set_slice(n as u32, update))),
-        (_, _, _) => Err(ExecError::Type("set_slice")),
+        (bits, n, update) => Err(ExecError::Type(format!("set_slice {:?} {:?} {:?}", &bits, &n, &update))),
     }
 }
 
@@ -1387,7 +1387,7 @@ pub fn vector_update<B: BV>(args: Vec<Val<B>>, solver: &mut Solver<B>, _: &mut L
             }
             _ => {
                 eprintln!("{:?}", args);
-                Err(ExecError::Type("vector_update (index)"))
+                Err(ExecError::Type(format!("vector_update (index) {:?}", &args[1])))
             }
         },
         Val::Bits(_) => {
@@ -1398,7 +1398,7 @@ pub fn vector_update<B: BV>(args: Vec<Val<B>>, solver: &mut Solver<B>, _: &mut L
         Val::Symbolic(v) if solver.is_bitvector(v) => {
             set_slice_internal(arg0, args[1].clone(), args[2].clone(), solver)
         }
-        _ => Err(ExecError::Type("vector_update")),
+        _ => Err(ExecError::Type(format!("vector_update {:?}", &arg0))),
     }
 }
 
@@ -1445,10 +1445,10 @@ fn get_slice_int_internal<B: BV>(
                 }
                 _ => slice!(128, smt_i128(n), from, length, solver),
             },
-            _ => Err(ExecError::Type("get_slice_int")),
+            _ => Err(ExecError::Type(format!("get_slice_int {:?}", &length))),
         },
         Val::Symbolic(_) => Err(ExecError::SymbolicLength("get_slice_int")),
-        _ => Err(ExecError::Type("get_slice_int")),
+        _ => Err(ExecError::Type(format!("get_slice_int length is {:?}", &length))),
     }
 }
 
@@ -1463,14 +1463,14 @@ fn unimplemented<B: BV>(_: Vec<Val<B>>, _: &mut Solver<B>, _: &mut LocalFrame<B>
 fn eq_string<B: BV>(lhs: Val<B>, rhs: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match (lhs, rhs) {
         (Val::String(lhs), Val::String(rhs)) => Ok(Val::Bool(lhs == rhs)),
-        (_, _) => Err(ExecError::Type("eq_string")),
+        (lhs, rhs) => Err(ExecError::Type(format!("eq_string {:?} {:?}", &lhs, &rhs))),
     }
 }
 
 fn concat_str<B: BV>(lhs: Val<B>, rhs: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match (lhs, rhs) {
         (Val::String(lhs), Val::String(rhs)) => Ok(Val::String(format!("{}{}", lhs, rhs))),
-        (_, _) => Err(ExecError::Type("concat_str")),
+        (lhs, rhs) => Err(ExecError::Type(format!("concat_str {:?} {:?}", &lhs, &rhs))),
     }
 }
 
@@ -1478,7 +1478,7 @@ fn hex_str<B: BV>(n: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match n {
         Val::I128(n) => Ok(Val::String(format!("0x{:x}", n))),
         Val::Symbolic(v) => Ok(Val::String(format!("0x[{}]", v))),
-        _ => Err(ExecError::Type("hex_str")),
+        _ => Err(ExecError::Type(format!("hex_str {:?}", &n))),
     }
 }
 
@@ -1486,7 +1486,7 @@ fn dec_str<B: BV>(n: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match n {
         Val::I128(n) => Ok(Val::String(format!("{}", n))),
         Val::Symbolic(v) => Ok(Val::String(format!("[{}]", v))),
-        _ => Err(ExecError::Type("dec_str")),
+        _ => Err(ExecError::Type(format!("dec_str {:?}", &n))),
     }
 }
 
@@ -1503,7 +1503,7 @@ fn string_to_i128<B: BV>(s: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecErr
             Err(ExecError::Overflow)
         }
     } else {
-        Err(ExecError::Type("%string->%int"))
+        Err(ExecError::Type(format!("%string->%int {:?}", &s)))
     }
 }
 
@@ -1529,14 +1529,14 @@ fn eq_anything<B: BV>(lhs: Val<B>, rhs: Val<B>, solver: &mut Solver<B>) -> Resul
             for (k, lhs_v) in lhs {
                 let rhs_v = match rhs.get(&k) {
                     Some(v) => v,
-                    None => return Err(ExecError::Type("eq_anything")),
+                    None => return Err(ExecError::Type("eq_anything None".to_string())),
                 };
                 let result = eq_anything(lhs_v, rhs_v.clone(), solver)?;
                 match result {
                     Val::Bool(true) => (),
                     Val::Bool(false) => return Ok(Val::Bool(false)),
                     Val::Symbolic(r) => vars.push(r),
-                    _ => return Err(ExecError::Type("eq_anything")),
+                    _ => return Err(ExecError::Type(format!("eq_anything {:?}", &result))),
                 }
             }
             match vars.pop() {
@@ -1551,7 +1551,7 @@ fn eq_anything<B: BV>(lhs: Val<B>, rhs: Val<B>, solver: &mut Solver<B>) -> Resul
             }
         }
 
-        (_, _) => Err(ExecError::Type("eq_anything")),
+        (lhs, rhs) => Err(ExecError::Type(format!("eq_anything {:?} {:?}", &lhs, &rhs))),
     }
 }
 
@@ -1576,14 +1576,14 @@ fn neq_anything<B: BV>(lhs: Val<B>, rhs: Val<B>, solver: &mut Solver<B>) -> Resu
         }
         (Val::Enum(lhs), Val::Enum(rhs)) => Ok(Val::Bool(lhs != rhs)),
 
-        (_, _) => Err(ExecError::Type("neq_anything")),
+        (lhs, rhs) => Err(ExecError::Type(format!("neq_anything {:?} {:?}", &lhs, &rhs))),
     }
 }
 
 fn string_startswith<B: BV>(s: Val<B>, prefix: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match (s, prefix) {
         (Val::String(s), Val::String(prefix)) => Ok(Val::Bool(s.starts_with(&prefix))),
-        _ => Err(ExecError::Type("string_startswith")),
+        other => Err(ExecError::Type(format!("string_startswith {:?}", &other))),
     }
 }
 
@@ -1591,21 +1591,21 @@ fn string_length<B: BV>(s: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecErro
     if let Val::String(s) = s {
         Ok(Val::I128(s.len() as i128))
     } else {
-        Err(ExecError::Type("string_length"))
+        Err(ExecError::Type(format!("string_length {:?}", &s)))
     }
 }
 
 fn string_drop<B: BV>(s: Val<B>, n: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match (s, n) {
         (Val::String(s), Val::I128(n)) => Ok(Val::String(s.get((n as usize)..).unwrap_or("").to_string())),
-        _ => Err(ExecError::Type("string_drop")),
+        other => Err(ExecError::Type(format!("string_drop {:?}", &other))),
     }
 }
 
 fn string_take<B: BV>(s: Val<B>, n: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecError> {
     match (s, n) {
         (Val::String(s), Val::I128(n)) => Ok(Val::String(s.get(..(n as usize)).unwrap_or(&s).to_string())),
-        _ => Err(ExecError::Type("string_take")),
+        other => Err(ExecError::Type(format!("string_take {:?}", &other))),
     }
 }
 
@@ -1613,7 +1613,7 @@ fn string_of_bits<B: BV>(bv: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecEr
     match bv {
         Val::Bits(bv) => Ok(Val::String(format!("{}", bv))),
         Val::Symbolic(v) => Ok(Val::String(format!("v{}", v))),
-        _ => Err(ExecError::Type("string_of_bits")),
+        other => Err(ExecError::Type(format!("string_of_bits {:?}", &other))),
     }
 }
 
@@ -1621,7 +1621,7 @@ fn decimal_string_of_bits<B: BV>(bv: Val<B>, _: &mut Solver<B>) -> Result<Val<B>
     match bv {
         Val::Bits(bv) => Ok(Val::String(format!("{}", bv.signed()))),
         Val::Symbolic(v) => Ok(Val::String(format!("v{}", v))),
-        _ => Err(ExecError::Type("decimal_string_of_bits")),
+        other => Err(ExecError::Type(format!("decimal_string_of_bits {:?}", &other))),
     }
 }
 
@@ -1629,7 +1629,7 @@ fn string_of_int<B: BV>(n: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecErro
     match n {
         Val::I128(n) => Ok(Val::String(format!("{}", n))),
         Val::Symbolic(v) => Ok(Val::String(format!("v{}", v))),
-        _ => Err(ExecError::Type("string_of_int")),
+        other => Err(ExecError::Type(format!("string_of_int {:?}", &other))),
     }
 }
 
@@ -1696,7 +1696,7 @@ fn undefined_bitvector<B: BV>(sz: Val<B>, solver: &mut Solver<B>) -> Result<Val<
     if let Val::I128(sz) = sz {
         solver.declare_const(Ty::BitVec(sz as u32)).into()
     } else {
-        Err(ExecError::Type("undefined_bitvector"))
+        Err(ExecError::Type(format!("undefined_bitvector {:?}", &sz)))
     }
 }
 
@@ -1738,7 +1738,7 @@ fn one_if<B: BV>(condition: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, Ex
                 Box::new(smt_sbits(B::BIT_ZERO)),
             ))
             .into(),
-        _ => Err(ExecError::Type("one_if")),
+        _ => Err(ExecError::Type(format!("one_if {:?}", &condition))),
     }
 }
 
@@ -1753,7 +1753,7 @@ fn zero_if<B: BV>(condition: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, E
                 Box::new(smt_sbits(B::BIT_ONE)),
             ))
             .into(),
-        _ => Err(ExecError::Type("one_if")),
+            other => Err(ExecError::Type(format!("one_if {:?}", &other))),
     }
 }
 
@@ -1765,7 +1765,7 @@ fn cons<B: BV>(x: Val<B>, xs: Val<B>, _: &mut Solver<B>) -> Result<Val<B>, ExecE
             xs.push(x);
             Ok(Val::List(xs))
         }
-        _ => Err(ExecError::Type("cons")),
+        _ => Err(ExecError::Type(format!("cons {:?}", &xs))),
     }
 }
 
@@ -1778,7 +1778,7 @@ pub fn smt_value<B: BV>(v: &Val<B>) -> Result<Exp, ExecError> {
         Val::Bool(b) => Exp::Bool(*b),
         Val::Enum(e) => Exp::Enum(*e),
         Val::Symbolic(v) => Exp::Var(*v),
-        _ => return Err(ExecError::Type("smt_value")),
+        _ => return Err(ExecError::Type(format!("smt_value {:?}", &v))),
     })
 }
 
@@ -1809,7 +1809,7 @@ fn choice<B: BV>(xs: Val<B>, solver: &mut Solver<B>) -> Result<Val<B>, ExecError
             solver.add(Def::DefineConst(choice, choice_chain(sym, 0, sz, xs)?));
             Ok(Val::Symbolic(choice))
         }
-        _ => Err(ExecError::Type("choice")),
+        _ => Err(ExecError::Type(format!("choice {:?}", &xs))),
     }
 }
 
@@ -1917,7 +1917,7 @@ fn mark_register<B: BV>(val: Val<B>, mark: Val<B>, solver: &mut Solver<B>) -> Re
             solver.add_event(Event::MarkReg { reg, mark });
             Ok(Val::Unit)
         }
-        _ => Err(ExecError::Type("mark_register")),
+        (val, mark) => Err(ExecError::Type(format!("mark_register {:?} {:?}", &val, &mark))),
     }
 }
 
@@ -1973,10 +1973,10 @@ fn count_leading_zeros<B: BV>(bv: Val<B>, solver: &mut Solver<B>) -> Result<Val<
             if let Some(len) = solver.length(bv) {
                 smt_clz(bv, len, solver).into()
             } else {
-                Err(ExecError::Type("count_leading_zeros"))
+                Err(ExecError::Type(format!("count_leading_zeros (solver could not determine length)")))
             }
         }
-        _ => Err(ExecError::Type("count_leading_zeros")),
+        _ => Err(ExecError::Type(format!("count_leading_zeros {:?}", &bv))),
     }
 }
 
@@ -1986,7 +1986,7 @@ fn build_ite<B: BV>(b: Sym, lhs: &Val<B>, rhs: &Val<B>, solver: &mut Solver<B>) 
             let fields: Result<_, _> = l_fields
                 .iter()
                 .map(|(k, l_val)| match r_fields.get(k) {
-                    None => Err(ExecError::Type("build_ite")),
+                    None => Err(ExecError::Type(format!("build_ite {:?}", &k))),
                     Some(r_val) => Ok((*k, build_ite(b, l_val, r_val, solver)?)),
                 })
                 .collect();
@@ -2003,7 +2003,7 @@ fn ite<B: BV>(args: Vec<Val<B>>, solver: &mut Solver<B>, _: &mut LocalFrame<B>) 
         Val::Symbolic(b) => build_ite(b, &args[1], &args[2], solver),
         Val::Bool(true) => Ok(args[1].clone()),
         Val::Bool(false) => Ok(args[2].clone()),
-        _ => Err(ExecError::Type("ite")),
+        _ => Err(ExecError::Type(format!("ite {:?}", &args[0]))),
     }
 }
 

--- a/isla-lib/src/smt.rs
+++ b/isla-lib/src/smt.rs
@@ -1192,7 +1192,7 @@ impl<'ctx, B: BV> Model<'ctx, B> {
 
     pub fn get_var(&mut self, var: Sym) -> Result<Option<Exp>, ExecError> {
         let var_ast = match self.solver.decls.get(&var) {
-            None => return Err(ExecError::Type("Unbound variable")),
+            None => return Err(ExecError::Type(format!("Unbound variable {:?}", &var))),
             Some(ast) => ast.clone(),
         };
         self.get_ast(var_ast)
@@ -1253,7 +1253,7 @@ impl<'ctx, B: BV> Model<'ctx, B> {
                 Z3_dec_ref(z3_ctx, Z3_func_decl_to_ast(z3_ctx, func_decl));
                 result
             } else {
-                Err(ExecError::Type("get_ast"))
+                Err(ExecError::Type("get_ast".to_string()))
             };
 
             Z3_dec_ref(z3_ctx, Z3_sort_to_ast(z3_ctx, sort));


### PR DESCRIPTION
Switch to an owned string, include context in the error messages.

Fixes #13