### PR TITLE
add make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ all: isla
 isla:
 	cargo build --release
 
+check:
+	cargo check --release
+
 isla-sail:
 	$(MAKE) -C isla-sail isla-sail
 


### PR DESCRIPTION
running `cargo check` is nice when testing things out because `cargo build` is slow