### PR TITLE
Add back temporary idmap of extra sections

### DIFF
--- a/isla-axiomatic/src/page_table/setup.rs
+++ b/isla-axiomatic/src/page_table/setup.rs
@@ -686,6 +686,13 @@ pub fn armv8_page_tables<B: BV>(
         page += isa_config.page_size
     }
 
+    // map all the section.* regions
+    // pretending they start at 0x1000
+    for i in 0..8 {
+        s1_tables.identity_map(s1_level0, 0x1000 * i, S1PageAttrs::code()).unwrap();
+        s2_tables.identity_map(s2_level0, 0x1000 * i, S2PageAttrs::code()).unwrap();
+    }
+
     memory.add_region(Region::Custom(s1_tables.range(), Box::new(s1_tables.freeze())));
     memory.add_region(Region::Custom(s2_tables.range(), Box::new(s2_tables.freeze())));
 


### PR DESCRIPTION
The old code used to generate 8 4K sections starting at 0x1000
as identically-mapped code pages.

This commit adds that back so the tests work,
but we should really read the sections from the .toml and then map those
explicitly.