### PR TITLE
Support threads with empty code section

### DIFF
--- a/configs/armv8p5.toml
+++ b/configs/armv8p5.toml
@@ -2,6 +2,8 @@
 
 pc = "_PC"
 
+comment_prefixes = ["@", "//"]
+
 translation_function = "AArch64_TranslateAddress"
 
 in_program_order = ["sail_barrier"]

--- a/configs/armv8p5_mmu_on.toml
+++ b/configs/armv8p5_mmu_on.toml
@@ -2,6 +2,8 @@
 
 pc = "_PC"
 
+comment_prefixes = ["@", "//"]
+
 translation_function = "AArch64_TranslateAddress"
 
 # The assembler is used for assembling the code in litmus tests. We

--- a/configs/armv9p3.toml
+++ b/configs/armv9p3.toml
@@ -2,6 +2,8 @@
 
 pc = "_PC"
 
+comment_prefixes = ["@", "//"]
+
 translation_function = "AArch64_TranslateAddress"
 
 in_program_order = ["sail_barrier", "sail_cache_op", "sail_take_exception", "sail_return_exception", "sail_tlbi"]

--- a/configs/armv9p3_mmu_on.toml
+++ b/configs/armv9p3_mmu_on.toml
@@ -2,6 +2,8 @@
 
 pc = "_PC"
 
+comment_prefixes = ["@", "//"]
+
 in_program_order = ["sail_barrier", "sail_cache_op", "sail_take_exception", "sail_return_exception", "sail_tlbi"]
 
 translation_function = "AArch64_TranslateAddress"

--- a/configs/armv9p4.toml
+++ b/configs/armv9p4.toml
@@ -2,6 +2,8 @@
 
 pc = "_PC"
 
+comment_prefixes = ["@", "//"]
+
 translation_function = "AArch64_TranslateAddress"
 
 # TODO: BS: implement in isla-axiomatic properly...

--- a/configs/armv9p4_mmu_on.toml
+++ b/configs/armv9p4_mmu_on.toml
@@ -2,6 +2,8 @@
 
 pc = "_PC"
 
+comment_prefixes = ["@", "//"]
+
 translation_function = "AArch64_TranslateAddress"
 
 # TODO: BS: implement in isla-axiomatic properly...

--- a/configs/riscv32.toml
+++ b/configs/riscv32.toml
@@ -2,6 +2,8 @@
 
 pc = "PC"
 
+comment_prefixes = ["#", "//"]
+
 # No ifetch semantics for RISC-V
 ifetch = "Read_ifetch"
 

--- a/configs/riscv64.toml
+++ b/configs/riscv64.toml
@@ -2,6 +2,8 @@
 
 pc = "PC"
 
+comment_prefixes = ["#", "//"]
+
 zero_announce_exit = true
 
 default_sizeof = 4

--- a/configs/riscv64_ubuntu.toml
+++ b/configs/riscv64_ubuntu.toml
@@ -2,6 +2,8 @@
 
 pc = "PC"
 
+comment_prefixes = ["#", "//"]
+
 # No ifetch semantics for RISC-V
 ifetch = "Read_ifetch"
 

--- a/isla-axiomatic/src/litmus.rs
+++ b/isla-axiomatic/src/litmus.rs
@@ -117,6 +117,7 @@ type SectionName = String;
 /// to an IR function
 enum ThreadBody<'a> {
     Code(&'a str),
+    Empty(&'a str),  // Thread with no instructions, but string preserved for potential labels/comments
     Call(Name),
 }
 
@@ -189,14 +190,13 @@ fn generate_linker_script<B>(
 
     loop {
         let line = match (threads.get(t), sections.get(s)) {
-            // For a non-code thread we don't generate anything, so increment t and try the next thread
-            (Some((_, body)), _) if !matches!(body, ThreadBody::Code(_)) => {
+            (Some((_, ThreadBody::Call(_))), _) => {
                 t += 1;
                 continue;
             }
-            (Some((tid, _)), Some(section)) if thread_address < section.address => Thread(tid),
-            (Some(_), Some(section)) => Section(section),
-            (Some((tid, _)), None) => Thread(tid),
+            (Some((tid, ThreadBody::Code(_) | ThreadBody::Empty(_))), Some(section)) if thread_address < section.address => Thread(tid),
+            (Some((_, ThreadBody::Code(_) | ThreadBody::Empty(_))), Some(section)) => Section(section),
+            (Some((tid, ThreadBody::Code(_) | ThreadBody::Empty(_))), None) => Thread(tid),
             (None, Some(section)) => Section(section),
             (None, None) => break,
         };
@@ -269,6 +269,36 @@ fn validate_code(_: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn contains_no_code<B: BV>(code: &str, isa: &ISAConfig<B>) -> bool {
+    let comment_prefixes = &isa.comment_prefixes;
+
+    for line in code.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if comment_prefixes.iter().any(|prefix| trimmed.starts_with(prefix)) {
+            continue;
+        }
+
+        if let Some(colon_pos) = trimmed.find(':') {
+            let after_colon = trimmed[colon_pos + 1..].trim();
+            if after_colon.is_empty() {
+                continue;
+            }
+            if comment_prefixes.iter().any(|prefix| after_colon.starts_with(prefix)) {
+                continue;
+            }
+        }
+
+        return false;
+    }
+
+    true
+}
+
 fn requires_assembly(threads: &[(ThreadName, ThreadBody)]) -> bool {
     for (_, body) in threads.iter() {
         if matches!(body, ThreadBody::Code(_)) {
@@ -316,12 +346,15 @@ fn assemble<B>(
     {
         let stdin = assembler.stdin.as_mut().ok_or_else(|| "Failed to open stdin for assembler".to_string())?;
         for (thread_name, body) in threads.iter() {
-            if let ThreadBody::Code(code) = body {
-                validate_code(code)?;
-                stdin
-                    .write_all(format!("\t.section {}{}, \"xa\"\n", THREAD_PREFIX, thread_name).as_bytes())
-                    .and_then(|_| stdin.write_all(code.as_bytes()))
-                    .map_err(|_| format!("Failed to write to assembler input file {}", objfile.path().display()))?
+            match body {
+                ThreadBody::Code(code) | ThreadBody::Empty(code) => {
+                    validate_code(code)?;
+                    stdin
+                        .write_all(format!("\t.section {}{}, \"xa\"\n", THREAD_PREFIX, thread_name).as_bytes())
+                        .and_then(|_| stdin.write_all(code.as_bytes()))
+                        .map_err(|_| format!("Failed to write to assembler input file {}", objfile.path().display()))?
+                }
+                ThreadBody::Call(_) => {}
             }
         }
         for section in sections {
@@ -431,6 +464,21 @@ fn assemble<B>(
         Ok(_) => return Err("Generated object was not an ELF file".to_string()),
         Err(err) => return Err(format!("Failed to parse ELF file: {}", err)),
     };
+
+    let mut thread_address = isa.thread_base;
+    for (thread_name, body) in threads.iter() {
+        match body {
+            ThreadBody::Empty(_) => {
+                log!(log::LITMUS, &format!("Thread {} is empty, adding with address 0x{:x}", thread_name, thread_address));
+                assembled_threads.insert(thread_name.to_string(), (thread_address, Vec::new()));
+                thread_address += isa.thread_stride;
+            }
+            ThreadBody::Code(_) => {
+                thread_address += isa.thread_stride;
+            }
+            ThreadBody::Call(_) => {}
+        }
+    }
 
     log!(log::LITMUS, &format!("Objdump:\n{}", objdump));
     log!(log::LITMUS, &format!("Names:\n{}", names));
@@ -1019,7 +1067,14 @@ impl<B: BV> Litmus<B> {
             .map(|(thread_name, thread)| match thread.get("code") {
                 Some(code) => code
                     .as_str()
-                    .map(|code| (thread_name.to_string(), ThreadBody::Code(code)))
+                    .map(|code| {
+                        if contains_no_code(code, isa) {
+                            log!(log::LITMUS, &format!("Thread {} has empty code", thread_name));
+                            (thread_name.to_string(), ThreadBody::Empty(code))
+                        } else {
+                            (thread_name.to_string(), ThreadBody::Code(code))
+                        }
+                    })
                     .ok_or_else(|| "thread code must be a string".to_string()),
                 None => match thread.get("call") {
                     Some(call) => {
@@ -1061,7 +1116,7 @@ impl<B: BV> Litmus<B> {
             .drain(..)
             .zip(inits.drain(..))
             .map(|((name, body), init)| match body {
-                ThreadBody::Code(source) => {
+                ThreadBody::Code(source) | ThreadBody::Empty(source) => {
                     let (address, code) =
                         assembled.remove(&name).ok_or(format!("Thread {} was not found in assembled threads", name))?;
                     Ok(Thread::Assembled(AssembledThread {

--- a/isla-lib/src/config.rs
+++ b/isla-lib/src/config.rs
@@ -591,6 +591,24 @@ fn get_default_sizeof(config: &Value) -> Result<u32, String> {
     }
 }
 
+fn get_comment_prefixes(config: &Value) -> Result<Vec<String>, String> {
+    let Some(v) = config.get("comment_prefixes") else { return Ok(Vec::new()) };
+
+    let Some(arr) = v.as_array() else {
+        return Err("comment_prefixes should be an array in configuration".to_string());
+    };
+
+    let mut prefixes = Vec::new();
+    for item in arr {
+        let Some(s) = item.as_str() else {
+            return Err("comment_prefixes should contain strings in configuration".to_string());
+        };
+        prefixes.push(s.to_string());
+    }
+
+    Ok(prefixes)
+}
+
 pub struct ISAConfig<B> {
     /// The identifier for the program counter register
     pub pc: Name,
@@ -657,6 +675,8 @@ pub struct ISAConfig<B> {
     pub default_sizeof: u32,
     /// Exit if sail_instr_announce is called with a zero bitvector
     pub zero_announce_exit: bool,
+    /// Comment prefixes for the assembly language (used to detect empty threads)
+    pub comment_prefixes: Vec<String>,
 }
 
 impl<B: BV> ISAConfig<B> {
@@ -715,6 +735,7 @@ impl<B: BV> ISAConfig<B> {
             in_program_order: get_in_program_order(&config, symtab)?,
             default_sizeof: get_default_sizeof(&config)?,
             zero_announce_exit: get_zero_announce_exit(&config)?,
+            comment_prefixes: get_comment_prefixes(&config)?,
         })
     }
 


### PR DESCRIPTION
Empty threads (i.e. only comments/labels) are detected and manually added to `assembled` HashMap

Note: I believe empty thread sections are optimised away by the linker after resolving references, so labels in empty threads don't appear in nm output or debugging logs.

<details>

<summary>Here is the test I used for debugging this</summary>

```
arch = "AArch64"
name = "empty_thread_with_label"
symbolic = ["x"]

page_table_setup = """
	physical pa_x;
	x |-> pa_x;
	*pa_x = 0;
	identity 0x1000 with code;
	identity 0x2000 with code;
"""

[types]
"pa_x" = "uint64_t"

[thread.0]
code = """
	// Empty thread for testing label-only code
done:
"""

[thread.0.reset]
R0 = "x"
VBAR_EL1 = "extz(0x1000, 64)"
"PSTATE.EL" = "0b01"

[section.thread0_el1_handler]
address = "0x1000"
code = """
	ADRP X29,done
	ADD X29,X29,:lo12:done
	MSR ELR_EL1,X29
	ERET
"""

[thread.1]
code = """
	MOV X1,#42
	STR X1,[X0]
finish:
"""

[thread.1.reset]
R0 = "x"
VBAR_EL1 = "extz(0x2000, 64)"
"PSTATE.EL" = "0b01"

[section.thread1_el1_handler]
address = "0x2000"
code = """
	ADRP X29,finish
	ADD X29,X29,:lo12:finish
	MSR ELR_EL1,X29
	ERET
"""

[final]
expect = "sat"
assertion = "*pa_x = 42"
```

</details>

<details>

<summary>
The isla debug output
</summary>

```
No primop emulator_read_tag (Name { id: 2694 })
No primop emulator_write_tag (Name { id: 2695 })
[log]: Using separate footprint config
No primop emulator_read_tag (Name { id: 2694 })
No primop emulator_write_tag (Name { id: 2695 })
[log]: Architecture + config hash: e8e5a696bbc81521e437a60e0da93bbc32058f5a092e6dcf2a0aa39bbb3f1128
[log]: Parsing took: 21554ms
[log]: Thread 0 has empty code
[log]: Linker script:
start = 0;
ENTRY(start);
SECTIONS
{
  . = 0x1000;
  thread0_el1_handler : { *(thread0_el1_handler) }
  . = 0x2000;
  thread1_el1_handler : { *(thread1_el1_handler) }
  . = 0x400000;
  litmus_0 : { *(litmus_0) }
  . = 0x401000;
  litmus_1 : { *(litmus_1) }
}

[log]: Thread 0 is empty, adding with address 0x400000
[log]: Objdump:

/tmp/isla/isla_71834_1:     file format elf64-littleaarch64


Disassembly of section thread0_el1_handler:

0000000000001000 <thread0_el1_handler>:
    1000:       f0001ffd        adrp    x29, 400000 <start+0x400000>
    1004:       910003bd        add     x29, x29, #0x0
    1008:       d518403d        msr     elr_el1, x29
    100c:       d69f03e0        eret

Disassembly of section thread1_el1_handler:

0000000000002000 <thread1_el1_handler>:
    2000:       f0001ffd        adrp    x29, 401000 <start+0x401000>
    2004:       910023bd        add     x29, x29, #0x8
    2008:       d518403d        msr     elr_el1, x29
    200c:       d69f03e0        eret

Disassembly of section litmus_1:

0000000000401000 <finish-0x8>:
  401000:       d2800541        mov     x1, #0x2a                       // #42
  401004:       f9000001        str     x1, [x0]

[log]: Names:
0000000000401008 t finish
0000000000000000 A start

[log]: Thread 0 @ 0x400000
[log]: Thread 1 @ 0x401000
[log]: Section thread0_el1_handler @ 0x1000
[log]: Section thread1_el1_handler @ 0x2000
[log]: Symbolic execution took: 1135ms
[log]: Footprint cache: Some("/tmp")
[log]: Got 0 uncached concrete opcodes for footprint analysis
[log]: Footprint analysis symbolic execution took: 0ms
[log]: There are 0 footprints
[log]: There are 1 candidate executions
[log]: with 28431 events
[log]: generating smt for candidate
[log]: generating smt events
[log]: generating smt basic relations
[log]: generating smtlib
[log]: generating smt final assertion
[log]: generating final smt
[log]: accessor function fault_is_from_write
[log]: accessor function F
[log]: accessor function Ifetch
[log]: accessor function is_cacheop
[log]: accessor function ak_strength
[log]: accessor function is_fault
[log]: accessor function tlbi_asid
[log]: accessor function tlbi_vmid
[log]: accessor function TLBI
[log]: accessor function z_dmb
[log]: accessor function is_tlbi
[log]: accessor function tlbi_shareability
[log]: accessor function translation_vmid
[log]: accessor function cache_op_shareability
[log]: accessor function is_DxB
[log]: accessor function write_phys_addr
[log]: accessor function MSR
[log]: accessor function barrier_domain
[log]: accessor function TE
[log]: accessor function Explicit
[log]: accessor function tlbi_op
[log]: accessor function ERET
[log]: accessor function z_isb
[log]: accessor function read_phys_addr
[log]: accessor function cache_op_type
[log]: accessor function cache_op_scope
[log]: accessor function cacheop_phys_addr
[log]: accessor function translation_asid
[log]: accessor function tlbi_address
[log]: accessor function fault_type
[log]: accessor function is_atomic
[log]: accessor function cache_op_kind
[log]: accessor function fault_acc_type
[log]: accessor function acch0l0fzdata
[log]: accessor function barrier_types
[log]: accessor function z_dsb
[log]: accessor function tlbi_regime
[log]: finished generating /tmp/isla_candidate_emptythreadwithlabel_g0t0_71834_0.smt2
[log]: solver took: 771ms
[log]: output model written to /tmp/isla_candidate_emptythreadwithlabel_g0t0_71834_0_model.smt2
[log]: warning: failed to get final state for execution: Failed to get final register state: Failed to parse smt model: failed to interpret smt during parse: in '(phys_addr (store ((as const (Array Event (_ BitVec 64))) #x0000000000000000) W2_2035_1 #x0000000000600000))', '(store ((as const (Array Event (_ BitVec 64))) #x0000000000000000) W2_2035_1 #x0000000000600000)', '((as const (Array Event (_ BitVec 64))) #x0000000000000000)', Bad function call
empty_thread_with_label allowed (1 of 1) 2798ms .................................................... ?

```

</details>