### PR TITLE
Fix/Add PTE attributes and consider PTE values with non-default attributes interesting

### DIFF
--- a/isla-axiomatic/src/axiomatic.rs
+++ b/isla-axiomatic/src/axiomatic.rs
@@ -48,7 +48,7 @@ use isla_mml::memory_model;
 use crate::graph::GraphOpts;
 use crate::litmus::exp::Loc as LitmusLoc;
 use crate::litmus::Litmus;
-use crate::page_table::VirtualAddress;
+use crate::page_table::{PageAttrs, S1PageAttrs, S2PageAttrs, VirtualAddress};
 use crate::sexp::{InterpretError, SexpVal};
 use crate::smt_model::Model;
 
@@ -640,6 +640,31 @@ impl<'ev, B: BV> ExecutionInfo<'ev, B> {
         Translations::from_events(self.smt_events.iter().chain(self.other_events.iter()))
     }
 
+    /// Check if a PTE's initial value has non-default page/block descriptor
+    /// attributes. In isla, table descriptor attributes are hard-coded to
+    /// only the Valid bit being set, so attr_bits == 1 identifies entries
+    /// that are (almost certainly) table descriptors and these should not
+    /// be automatically interesting. A page/block descriptor with all
+    /// attributes zeroed except Valid would also match and be incorrectly
+    /// filtered out. This is a trade-off to avoid adding a large number
+    /// of uninteresting walk events.
+    fn pte_has_non_default_attrs(
+        initial: u64,
+        region: &str,
+        s1_attr_mask: u64,
+        s1_default: u64,
+        s2_attr_mask: u64,
+        s2_default: u64,
+    ) -> bool {
+        let (attr_mask, default) =
+            if region == "stage 1" { (s1_attr_mask, s1_default) } else { (s2_attr_mask, s2_default) };
+        let attr_bits = initial & attr_mask;
+        // attr_bits == 1: likely a table descriptor
+        // attr_bits == default: standard page/block attrs
+        // Note: an invalid entry (Valid=0) is non-default and interesting
+        attr_bits != 1 && attr_bits != default
+    }
+
     /// A transate event is uninteresting if it is guaranteed to read
     /// from the initial state. There are two modes for this function,
     /// if keep_entire_translation is true we will keep all the events
@@ -670,6 +695,12 @@ impl<'ev, B: BV> ExecutionInfo<'ev, B> {
         let mut write_addr_pgtable_setup: HashSet<u64> = HashSet::new();
         write_addr_pgtable_setup.extend(updated);
 
+        // Compute attribute masks and defaults for detecting non-default PTE attrs.
+        let (_, s1_attr_mask) = S1PageAttrs::unknown().bits();
+        let (s1_default, _) = S1PageAttrs::default().bits();
+        let (_, s2_attr_mask) = S2PageAttrs::unknown().bits();
+        let (s2_default, _) = S2PageAttrs::default().bits();
+
         let mut interesting = Vec::new();
         let mut uninteresting = Vec::new();
 
@@ -677,11 +708,21 @@ impl<'ev, B: BV> ExecutionInfo<'ev, B> {
             let mut interesting_translation = HashSet::new();
             for ax_event in self.smt_events.iter().filter(|ev| ev.translate.is_some()) {
                 match ax_event.base() {
-                    Some(Event::ReadMem { address: Val::Bits(bv), .. }) => {
+                    Some(Event::ReadMem { address: Val::Bits(bv), region, .. }) => {
+                        let initial = match memory.read_initial(bv.lower_u64(), 8) {
+                            Ok(Val::Bits(b)) => b.lower_u64(),
+                            _ => 0,
+                        };
                         if write_addrs.contains(bv)
                             || write_addr_pgtable_setup.contains(&bv.lower_u64())
-                            || memory.read_initial(bv.lower_u64(), 8).unwrap_or_else(|_| Val::Bits(B::from_u64(0)))
-                                == Val::Bits(B::from_u64(0))
+                            || Self::pte_has_non_default_attrs(
+                                initial,
+                                region,
+                                s1_attr_mask,
+                                s1_default,
+                                s2_attr_mask,
+                                s2_default,
+                            )
                         {
                             interesting_translation.insert(ax_event.translate.unwrap());
                         }
@@ -703,11 +744,21 @@ impl<'ev, B: BV> ExecutionInfo<'ev, B> {
                     interesting.push(ax_event)
                 } else {
                     match ax_event.base() {
-                        Some(Event::ReadMem { address: Val::Bits(bv), .. }) => {
+                        Some(Event::ReadMem { address: Val::Bits(bv), region, .. }) => {
+                            let initial = match memory.read_initial(bv.lower_u64(), 8) {
+                                Ok(Val::Bits(b)) => b.lower_u64(),
+                                _ => 0,
+                            };
                             if write_addrs.contains(bv)
                                 || write_addr_pgtable_setup.contains(&bv.lower_u64())
-                                || memory.read_initial(bv.lower_u64(), 8).unwrap_or_else(|_| Val::Bits(B::from_u64(0)))
-                                    == Val::Bits(B::from_u64(0))
+                                || Self::pte_has_non_default_attrs(
+                                    initial,
+                                    region,
+                                    s1_attr_mask,
+                                    s1_default,
+                                    s2_attr_mask,
+                                    s2_default,
+                                )
                             {
                                 interesting.push(ax_event)
                             } else {

--- a/isla-axiomatic/src/litmus/exp.rs
+++ b/isla-axiomatic/src/litmus/exp.rs
@@ -456,7 +456,7 @@ fn mkdesc3<B: BV, P: Default + PageAttrs>(
     let (attrs, _) = attrs.bits();
 
     primop::or_bits(
-        primop::or_bits(oa, Val::Bits(B::from_u64(0b11)), solver, SourceLoc::unknown())?,
+        primop::or_bits(oa, Val::Bits(B::from_u64(0b10)), solver, SourceLoc::unknown())?,
         Val::Bits(B::from_u64(attrs)),
         solver,
         SourceLoc::unknown(),

--- a/isla-axiomatic/src/page_table.rs
+++ b/isla-axiomatic/src/page_table.rs
@@ -224,8 +224,8 @@ impl PageAttrs for S1PageAttrs {
         let mut set = 0;
         let mut unknown = 0;
 
-        attr_bool!(self.uxn, 53, set, unknown);
-        attr_bool!(self.pxn, 54, set, unknown);
+        attr_bool!(self.uxn, 54, set, unknown);
+        attr_bool!(self.pxn, 53, set, unknown);
         attr_bool!(self.contiguous, 52, set, unknown);
         attr_bool!(self.n_g, 11, set, unknown);
         attr_bool!(self.af, 10, set, unknown);
@@ -247,7 +247,7 @@ impl PageAttrs for S1PageAttrs {
 
         // Bit 53 is PXN (Privileged execute-never)
         if let Some(pxn) = self.pxn {
-            solver.assert_eq(Extract(54, 54, Box::new(Var(desc))), bool_to_bit(pxn))
+            solver.assert_eq(Extract(53, 53, Box::new(Var(desc))), bool_to_bit(pxn))
         }
 
         // Bit 52 is the contiguous bit
@@ -353,7 +353,7 @@ impl PageAttrs for S2PageAttrs {
         }
 
         // Bit 11 is always 0
-        solver.assert_eq(Extract(53, 53, Box::new(Var(desc))), bits64(0, 1));
+        solver.assert_eq(Extract(11, 11, Box::new(Var(desc))), bits64(0, 1));
 
         // Bit 10 is AF (access flag)
         if let Some(af) = self.af {

--- a/isla-axiomatic/src/page_table.rs
+++ b/isla-axiomatic/src/page_table.rs
@@ -58,25 +58,29 @@ pub struct S1PageAttrs {
     uxn: Option<bool>, // UXN in EL1&0 translation regime, XN in others
     pxn: Option<bool>,
     contiguous: Option<bool>,
+    dbm: Option<bool>,
     n_g: Option<bool>,
     af: Option<bool>,
     sh: Option<u8>,
     ap: Option<u8>,
     ns: Option<bool>,
     attr_indx: Option<u8>,
+    valid: Option<bool>,
 }
 
 // Names identical to ARM ARM
-const S1_PAGE_ATTR_FIELDS: [(&str, u64, u64); 9] = [
+const S1_PAGE_ATTR_FIELDS: [(&str, u64, u64); 11] = [
     ("UXN", 54, 54),
     ("PXN", 53, 53),
     ("Contiguous", 52, 52),
+    ("DBM", 51, 51),
     ("nG", 11, 11),
     ("AF", 10, 10),
     ("SH", 9, 8),
     ("AP", 7, 6),
     ("NS", 5, 5),
     ("AttrIndx", 4, 2),
+    ("Valid", 0, 0),
 ];
 
 impl Default for S1PageAttrs {
@@ -85,12 +89,14 @@ impl Default for S1PageAttrs {
             uxn: Some(false),
             pxn: Some(false),
             contiguous: Some(false),
+            dbm: Some(false),
             n_g: Some(false),
             af: Some(true),
             sh: Some(0b00),
             ap: Some(0b01),
             ns: Some(false),
             attr_indx: Some(0b000),
+            valid: Some(true),
         }
     }
 }
@@ -101,12 +107,14 @@ impl S1PageAttrs {
             uxn: Some(false),
             pxn: Some(false),
             contiguous: Some(false),
+            dbm: Some(false),
             n_g: Some(false),
             af: Some(true),
             sh: Some(0b00),
             ap: Some(0b11),
             ns: Some(false),
             attr_indx: Some(0b000),
+            valid: Some(true),
         }
     }
 }
@@ -115,26 +123,38 @@ impl S1PageAttrs {
 pub struct S2PageAttrs {
     xn: Option<bool>,
     contiguous: Option<bool>,
+    dbm: Option<bool>,
     af: Option<bool>,
     sh: Option<u8>,
     s2ap: Option<u8>,
     mem_attr: Option<u8>,
+    valid: Option<bool>,
 }
 
 // Names identical to ARM ARM
-const S2_PAGE_ATTR_FIELDS: [(&str, u64, u64); 6] =
-    [("XN", 54, 54), ("Contiguous", 52, 52), ("AF", 10, 10), ("SH", 9, 8), ("S2AP", 7, 6), ("MemAttr", 5, 2)];
+const S2_PAGE_ATTR_FIELDS: [(&str, u64, u64); 8] = [
+    ("XN", 54, 54),
+    ("Contiguous", 52, 52),
+    ("DBM", 51, 51),
+    ("AF", 10, 10),
+    ("SH", 9, 8),
+    ("S2AP", 7, 6),
+    ("MemAttr", 5, 2),
+    ("Valid", 0, 0),
+];
 
 impl Default for S2PageAttrs {
     fn default() -> Self {
         S2PageAttrs {
             xn: Some(false),
             contiguous: Some(false),
+            dbm: Some(false),
             af: Some(true),
             sh: Some(0b00),
             s2ap: Some(0b11),
             // normal/normal write-through read/write-allocate non-transient memory
             mem_attr: Some(0b1111),
+            valid: Some(true),
         }
     }
 }
@@ -144,11 +164,13 @@ impl S2PageAttrs {
         S2PageAttrs {
             xn: Some(false),
             contiguous: Some(false),
+            dbm: Some(false),
             af: Some(true),
             sh: Some(0b00),
             s2ap: Some(0b00),
             // normal/normal write-through read/write-allocate non-transient memory
             mem_attr: Some(0b1111),
+            valid: Some(true),
         }
     }
 }
@@ -207,12 +229,14 @@ impl PageAttrs for S1PageAttrs {
             uxn: None,
             pxn: None,
             contiguous: None,
+            dbm: None,
             n_g: None,
             af: None,
             sh: None,
             ap: None,
             ns: None,
             attr_indx: None,
+            valid: None,
         }
     }
 
@@ -227,12 +251,14 @@ impl PageAttrs for S1PageAttrs {
         attr_bool!(self.uxn, 54, set, unknown);
         attr_bool!(self.pxn, 53, set, unknown);
         attr_bool!(self.contiguous, 52, set, unknown);
+        attr_bool!(self.dbm, 51, set, unknown);
         attr_bool!(self.n_g, 11, set, unknown);
         attr_bool!(self.af, 10, set, unknown);
         attr_u8!(self.sh, 9, 8, set, unknown);
         attr_u8!(self.ap, 7, 6, set, unknown);
         attr_bool!(self.ns, 5, set, unknown);
         attr_u8!(self.attr_indx, 4, 2, set, unknown);
+        attr_bool!(self.valid, 0, set, unknown);
 
         (set, unknown)
     }
@@ -253,6 +279,11 @@ impl PageAttrs for S1PageAttrs {
         // Bit 52 is the contiguous bit
         if let Some(contiguous) = self.contiguous {
             solver.assert_eq(Extract(52, 52, Box::new(Var(desc))), bool_to_bit(contiguous))
+        }
+
+        // Bit 51 is DBM (Dirty Bit Modifier)
+        if let Some(dbm) = self.dbm {
+            solver.assert_eq(Extract(51, 51, Box::new(Var(desc))), bool_to_bit(dbm))
         }
 
         // Bit 11 is nG (not global bit)
@@ -284,6 +315,11 @@ impl PageAttrs for S1PageAttrs {
         if let Some(attr_indx) = self.attr_indx {
             solver.assert_eq(Extract(4, 2, Box::new(Var(desc))), bits64(attr_indx as u64 & 0b111, 3))
         }
+
+        // Bit 0 is Valid
+        if let Some(valid) = self.valid {
+            solver.assert_eq(Extract(0, 0, Box::new(Var(desc))), bool_to_bit(valid))
+        }
     }
 
     fn set_field<B: BV>(&mut self, attr: &str, bits: B) -> Option<()> {
@@ -300,12 +336,14 @@ impl PageAttrs for S1PageAttrs {
             "UXN" => self.uxn = Some(!bits.is_zero()),
             "PXN" => self.pxn = Some(!bits.is_zero()),
             "Contiguous" => self.contiguous = Some(!bits.is_zero()),
+            "DBM" => self.dbm = Some(!bits.is_zero()),
             "nG" => self.n_g = Some(!bits.is_zero()),
             "AF" => self.af = Some(!bits.is_zero()),
             "SH" => self.sh = Some(bits.lower_u8()),
             "AP" => self.ap = Some(bits.lower_u8()),
             "NS" => self.ns = Some(!bits.is_zero()),
             "AttrIndx" => self.attr_indx = Some(bits.lower_u8()),
+            "Valid" => self.valid = Some(!bits.is_zero()),
             _ => unreachable!(),
         }
 
@@ -315,7 +353,16 @@ impl PageAttrs for S1PageAttrs {
 
 impl PageAttrs for S2PageAttrs {
     fn unknown() -> Self {
-        S2PageAttrs { xn: None, contiguous: None, af: None, sh: None, s2ap: None, mem_attr: None }
+        S2PageAttrs {
+            xn: None,
+            contiguous: None,
+            dbm: None,
+            af: None,
+            sh: None,
+            s2ap: None,
+            mem_attr: None,
+            valid: None,
+        }
     }
 
     fn fields() -> &'static [(&'static str, u64, u64)] {
@@ -328,10 +375,12 @@ impl PageAttrs for S2PageAttrs {
 
         attr_bool!(self.xn, 54, set, unknown);
         attr_bool!(self.contiguous, 52, set, unknown);
+        attr_bool!(self.dbm, 51, set, unknown);
         attr_bool!(self.af, 10, set, unknown);
         attr_u8!(self.sh, 9, 8, set, unknown);
         attr_u8!(self.s2ap, 7, 6, set, unknown);
         attr_u8!(self.mem_attr, 5, 2, set, unknown);
+        attr_bool!(self.valid, 0, set, unknown);
 
         (set, unknown)
     }
@@ -350,6 +399,11 @@ impl PageAttrs for S2PageAttrs {
         // Bit 52 is the contiguous bit
         if let Some(contiguous) = self.contiguous {
             solver.assert_eq(Extract(52, 52, Box::new(Var(desc))), bool_to_bit(contiguous))
+        }
+
+        // Bit 51 is DBM (Dirty Bit Modifier)
+        if let Some(dbm) = self.dbm {
+            solver.assert_eq(Extract(51, 51, Box::new(Var(desc))), bool_to_bit(dbm))
         }
 
         // Bit 11 is always 0
@@ -374,6 +428,11 @@ impl PageAttrs for S2PageAttrs {
         if let Some(mem_attr) = self.mem_attr {
             solver.assert_eq(Extract(5, 2, Box::new(Var(desc))), bits64(mem_attr as u64 & 0b1111, 4))
         }
+
+        // Bit 0 is Valid
+        if let Some(valid) = self.valid {
+            solver.assert_eq(Extract(0, 0, Box::new(Var(desc))), bool_to_bit(valid))
+        }
     }
 
     fn set_field<B: BV>(&mut self, attr: &str, bits: B) -> Option<()> {
@@ -389,10 +448,12 @@ impl PageAttrs for S2PageAttrs {
         match attr {
             "XN" => self.xn = Some(!bits.is_zero()),
             "Contiguous" => self.contiguous = Some(!bits.is_zero()),
+            "DBM" => self.dbm = Some(!bits.is_zero()),
             "AF" => self.af = Some(!bits.is_zero()),
             "SH" => self.sh = Some(bits.lower_u8()),
             "S2AP" => self.s2ap = Some(bits.lower_u8()),
             "MemAttr" => self.mem_attr = Some(bits.lower_u8()),
+            "Valid" => self.valid = Some(!bits.is_zero()),
             _ => unreachable!(),
         }
 
@@ -442,7 +503,7 @@ pub fn page_desc_bits<P: PageAttrs>(page: u64, attrs: P) -> Option<u64> {
     let (attrs, unknowns) = attrs.bits();
 
     if unknowns == 0 {
-        Some((page & mask) | 0b11 | attrs)
+        Some((page & mask) | 0b10 | attrs)
     } else {
         None
     }
@@ -456,7 +517,7 @@ pub fn block_desc_bits<P: PageAttrs>(page: u64, attrs: P, level: u64) -> Option<
     let (attrs, unknowns) = attrs.bits();
 
     if unknowns == 0 {
-        Some((page & mask) | 0b01 | attrs)
+        Some((page & mask) | attrs)
     } else {
         None
     }


### PR DESCRIPTION
- `UXN` and `PXN` bit positions were swapped (Arm ARM M.a.a, D8-7629)
- Support more PTE attributes: `valid` and `dbm`
- The `--remove-uninteresting` heuristic unsoundly removed translation events with non-default attributes. For example, a read-only PTE value is very likely to be relevant, as similarly to an invalid entry it may cause a fault.